### PR TITLE
use elementId in DonmoRoundup component

### DIFF
--- a/components/DonmoRoundup.vue
+++ b/components/DonmoRoundup.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="donmo-roundup"></div>
+  <div :id="elementId"></div>
 </template>
 
 <script lang="ts">
@@ -8,6 +8,7 @@ import {
   onMounted,
   useContext,
   watch,
+  ref,
 } from "@nuxtjs/composition-api";
 
 import { useApi } from "~/composables/useApi";
@@ -21,6 +22,7 @@ export default defineComponent({
       type: String,
       required: true,
     },
+
     integrationTitle: {
       type: String,
     },
@@ -98,10 +100,15 @@ export default defineComponent({
 
     const getGrandTotal = () => cartGetters.getTotals(cart.value).total;
 
+    const elementId = ref(null);
+
     onMounted(() => {
+      elementId.value = "donmo-roundup-" + Math.floor(Math.random() * 1000);
+
       load().then(() => {
         const donmo = (window as any).DonmoRoundup({
           publicKey: props.publicKey,
+          elementId: elementId.value,
           isBackendBased: props.isBackendBased,
           language: props.language || i18n.locale,
           orderId: cart.value.id,
@@ -129,6 +136,10 @@ export default defineComponent({
         );
       });
     });
+
+    return {
+      elementId,
+    };
   },
 
   head() {
@@ -145,10 +156,3 @@ export default defineComponent({
   },
 });
 </script>
-
-<style lang="scss" scoped>
-#donmo-roundup {
-  margin-top: 5px;
-  margin-bottom: 15px;
-}
-</style>

--- a/modules/checkout/components/CartPreview.vue
+++ b/modules/checkout/components/CartPreview.vue
@@ -45,7 +45,10 @@
       />
     </div>
     <CouponCode class="highlighted" />
-    <DonmoRoundup v-if="showDonmoRoundup" :public-key="donmoPublicKey" />
+
+    <div id="donmo-cart-preview-wrapper">
+      <DonmoRoundup :public-key="donmoPublicKey" />
+    </div>
 
     <div class="highlighted">
       <SfCharacteristic
@@ -67,7 +70,7 @@ import useCart from "~/modules/checkout/composables/useCart";
 import getShippingMethodPrice from "~/helpers/checkout/getShippingMethodPrice";
 import CouponCode from "../../../components/CouponCode.vue";
 
-import DonmoRoundup from "~/modules/checkout/components/DonmoRoundup.vue";
+import DonmoRoundup from "~/components/DonmoRoundup.vue";
 
 const CHARACTERISTICS = [
   {
@@ -113,7 +116,7 @@ export default defineComponent({
     const donmoDonation = computed(
       () => cart.value?.prices?.["donmo_donation"]?.value
     );
-    const showDonmoRoundup = computed(() => screen.width >= 1024);
+
     const donmoPublicKey = computed(() => process.env.DONMO_PUBLIC_KEY);
     return {
       cart,
@@ -130,7 +133,6 @@ export default defineComponent({
       characteristics: CHARACTERISTICS,
       selectedShippingMethod,
 
-      showDonmoRoundup,
       donmoPublicKey,
       donmoDonation,
     };
@@ -139,6 +141,11 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
+#donmo-cart-preview-wrapper {
+  @include for-mobile {
+    display: none;
+  }
+}
 .highlighted {
   box-sizing: border-box;
   width: 100%;

--- a/modules/checkout/pages/Checkout/Payment.vue
+++ b/modules/checkout/pages/Checkout/Payment.vue
@@ -154,7 +154,9 @@
         </div>
       </div>
     </div>
-    <DonmoRoundup v-if="showDonmoRoundup" :public-key="donmoPublicKey" />
+    <div id="donmo-payment-wrapper">
+      <DonmoRoundup :public-key="donmoPublicKey" />
+    </div>
   </div>
 </template>
 
@@ -192,7 +194,7 @@ import type {
   CartItemInterface,
 } from "~/modules/GraphQL/types";
 
-import DonmoRoundup from "~/modules/checkout/components/DonmoRoundup.vue";
+import DonmoRoundup from "~/components/DonmoRoundup.vue";
 
 export default defineComponent({
   name: "ReviewOrderAndPayment",
@@ -258,7 +260,6 @@ export default defineComponent({
       cartGetters.getItemPrice(product).regular -
       cartGetters.getItemPrice(product).special;
 
-    const showDonmoRoundup = computed(() => screen.width < 1024);
     const donmoPublicKey = computed(() => process.env.DONMO_PUBLIC_KEY);
 
     return {
@@ -284,7 +285,6 @@ export default defineComponent({
       imageSizes,
       getRowTotal,
 
-      showDonmoRoundup,
       donmoPublicKey,
     };
   },
@@ -292,6 +292,13 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
+#donmo-payment-wrapper {
+  margin-top: 15px;
+
+  @include for-desktop {
+    display: none;
+  }
+}
 .title {
   margin: var(--spacer-xl) 0 var(--spacer-base) 0;
 }


### PR DESCRIPTION
- Include elementId param (allows to have several components(e.g., for mobile & desktop) on one page without `attachShadow` error) 
- Move component to `~/components`